### PR TITLE
Add explicit test project dependency in solution

### DIFF
--- a/WpfAppLauncher.sln
+++ b/WpfAppLauncher.sln
@@ -42,6 +42,9 @@ Global
 		{3EBAD921-6FD5-4341-A3B0-C15AFC59FF26}.Release|x86.ActiveCfg = Release|Any CPU
 		{3EBAD921-6FD5-4341-A3B0-C15AFC59FF26}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
+	GlobalSection(ProjectDependencies) = postSolution
+		{3EBAD921-6FD5-4341-A3B0-C15AFC59FF26}.0 = {D286BFE6-2FD5-4666-BD82-1DD69C3E993F}
+	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
 	EndGlobalSection

--- a/WpfAppLauncher.sln
+++ b/WpfAppLauncher.sln
@@ -6,6 +6,9 @@ MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfAppLauncher", "WpfAppLauncher\WpfAppLauncher.csproj", "{D286BFE6-2FD5-4666-BD82-1DD69C3E993F}"
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WpfAppLauncher.Tests", "WpfAppLauncher.Tests\WpfAppLauncher.Tests.csproj", "{3EBAD921-6FD5-4341-A3B0-C15AFC59FF26}"
+	ProjectSection(ProjectDependencies) = postProject
+		{D286BFE6-2FD5-4666-BD82-1DD69C3E993F} = {D286BFE6-2FD5-4666-BD82-1DD69C3E993F}
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
@@ -41,9 +44,6 @@ Global
 		{3EBAD921-6FD5-4341-A3B0-C15AFC59FF26}.Release|x64.Build.0 = Release|Any CPU
 		{3EBAD921-6FD5-4341-A3B0-C15AFC59FF26}.Release|x86.ActiveCfg = Release|Any CPU
 		{3EBAD921-6FD5-4341-A3B0-C15AFC59FF26}.Release|x86.Build.0 = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectDependencies) = postSolution
-		{3EBAD921-6FD5-4341-A3B0-C15AFC59FF26}.0 = {D286BFE6-2FD5-4666-BD82-1DD69C3E993F}
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- add an explicit dependency from the test project to the WPF application in the solution file so build order is enforced

## Testing
- `dotnet build WpfAppLauncher/WpfAppLauncher.csproj` *(fails: `dotnet` command not available in container environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f73c81d38c8328880a1c01ff9030c9