### PR TITLE
Add plugin extension infrastructure and management UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,3 +21,11 @@ Resides in the system tray for quick access and productivity.
 * 共通設定は `WpfAppLauncher/appsettings.json` に保存されます。アプリケーションデータの保存先、許可される拡張子、テーマボタンなどを変更できます。
 * ビルド構成ごとの設定は `appsettings.Development.json`（Debug）と `appsettings.Production.json`（Release）で上書きできます。既定では開発環境のアプリデータ保存先のみ分離しています。
 * 追加で安全な値を渡したい場合は、環境変数 `WPFAPPLAUNCHER_` プレフィックスを付けて設定できます（例：`WPFAPPLAUNCHER_AppData__ApplicationDirectoryName`）。`DOTNET_ENVIRONMENT` または `ASPNETCORE_ENVIRONMENT` を指定すると読み込まれる環境設定ファイルを切り替えられます。
+
+## 🧩 拡張機能
+
+* アプリ起動時に `Extensions` フォルダー（`appsettings.json` の `Extensions:DirectoryName` で変更可能）以下の DLL を自動検出し、`*.Extension.dll` という命名規約に合致するアセンブリから拡張機能をロードします。
+* 拡張機能のエントリーポイントは `IAppExtension` を実装し、`[ExtensionMetadata("id", "表示名", "1.0.0")]` 属性でメタデータを宣言してください。属性の `Description` プロパティを利用すると UI に概要が表示されます。
+* 拡張機能ごとのデータは `%AppData%/WpfAppLauncher/Extensions/<拡張機能ID>`（`Extensions:DataDirectoryName`）以下に保存されます。初期化時に `ExtensionInitializationContext` からロガーや構成情報へアクセスできます。
+* 有効・無効の状態は `Extensions:StateFileName`（既定: `extensions.json`）に保持され、アプリの「拡張機能...」ボタンから UI で切り替えられます。構成ファイル側 (`Extensions:Disabled`) で明示的に無効化したプラグインは UI から変更できません。
+* 拡張 DLL の更新や追加・削除を検出すると自動で再読み込みします。必要に応じて管理画面の「再読み込み」ボタンから手動で反映させることもできます。

--- a/WpfAppLauncher/Configuration/AppSettings.cs
+++ b/WpfAppLauncher/Configuration/AppSettings.cs
@@ -7,6 +7,7 @@ namespace WpfAppLauncher.Configuration
         public AppDataSettings AppData { get; set; } = new();
         public DragDropSettings DragDrop { get; set; } = new();
         public ThemeSettings Themes { get; set; } = new();
+        public ExtensionSettings Extensions { get; set; } = new();
     }
 
     public class AppDataSettings
@@ -38,5 +39,15 @@ namespace WpfAppLauncher.Configuration
         public string Name { get; set; } = string.Empty;
         public string? Icon { get; set; }
         public string? Tooltip { get; set; }
+    }
+
+    public class ExtensionSettings
+    {
+        public string DirectoryName { get; set; } = "Extensions";
+        public string DataDirectoryName { get; set; } = "Extensions";
+        public string SearchPattern { get; set; } = "*.Extension.dll";
+        public string StateFileName { get; set; } = "extensions.json";
+        public bool WatchForChanges { get; set; } = true;
+        public List<string> Disabled { get; set; } = new();
     }
 }

--- a/WpfAppLauncher/Extensions/ExtensionHost.cs
+++ b/WpfAppLauncher/Extensions/ExtensionHost.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace WpfAppLauncher.Extensions
+{
+    public static class ExtensionHost
+    {
+        private static readonly object SyncRoot = new();
+        private static ExtensionManager? _manager;
+
+        public static bool IsInitialized => _manager is not null;
+
+        public static ExtensionManager Manager => _manager ?? throw new InvalidOperationException("拡張機能マネージャーが初期化されていません。");
+
+        internal static void Initialize(ExtensionManager manager)
+        {
+            ArgumentNullException.ThrowIfNull(manager);
+
+            lock (SyncRoot)
+            {
+                _manager?.Dispose();
+                _manager = manager;
+            }
+        }
+
+        internal static void Shutdown()
+        {
+            lock (SyncRoot)
+            {
+                _manager?.Dispose();
+                _manager = null;
+            }
+        }
+    }
+}

--- a/WpfAppLauncher/Extensions/ExtensionInitializationContext.cs
+++ b/WpfAppLauncher/Extensions/ExtensionInitializationContext.cs
@@ -1,0 +1,51 @@
+using System;
+using Microsoft.Extensions.Configuration;
+using Serilog;
+
+namespace WpfAppLauncher.Extensions
+{
+    /// <summary>
+    /// 拡張機能の初期化時にホストから渡される情報を表します。
+    /// </summary>
+    public sealed class ExtensionInitializationContext
+    {
+        public ExtensionInitializationContext(
+            IServiceProvider? services,
+            IConfiguration configuration,
+            ILogger logger,
+            string extensionsDirectory,
+            string extensionDataDirectory)
+        {
+            Services = services;
+            Configuration = configuration;
+            Logger = logger;
+            ExtensionsDirectory = extensionsDirectory;
+            ExtensionDataDirectory = extensionDataDirectory;
+        }
+
+        /// <summary>
+        /// ホストが公開しているサービスプロバイダー。利用できない場合は <c>null</c> です。
+        /// </summary>
+        public IServiceProvider? Services { get; }
+
+        /// <summary>
+        /// アプリケーションの構成情報。
+        /// </summary>
+        public IConfiguration Configuration { get; }
+
+        /// <summary>
+        /// 拡張機能専用のロガー。
+        /// </summary>
+        public ILogger Logger { get; }
+
+        /// <summary>
+        /// 拡張機能 DLL が配置されているディレクトリ。
+        /// </summary>
+        public string ExtensionsDirectory { get; }
+
+        /// <summary>
+        /// 拡張機能がデータファイルを保存するためのディレクトリ。
+        /// </summary>
+        public string ExtensionDataDirectory { get; }
+    }
+}

--- a/WpfAppLauncher/Extensions/ExtensionListItem.cs
+++ b/WpfAppLauncher/Extensions/ExtensionListItem.cs
@@ -1,0 +1,106 @@
+using System;
+using System.ComponentModel;
+using System.Runtime.CompilerServices;
+
+namespace WpfAppLauncher.Extensions
+{
+    internal sealed class ExtensionListItem : INotifyPropertyChanged
+    {
+        private bool _isEnabled;
+        private string _statusMessage = string.Empty;
+        private string _lastUpdatedDisplay = string.Empty;
+
+        public ExtensionListItem(ExtensionSnapshot snapshot)
+        {
+            Id = snapshot.Id;
+            DisplayName = snapshot.DisplayName;
+            Description = snapshot.Description;
+            Version = snapshot.Version;
+            AssemblyPath = snapshot.AssemblyPath;
+            Update(snapshot);
+        }
+
+        public string Id { get; }
+
+        public string DisplayName { get; }
+
+        public string? Description { get; }
+
+        public string Version { get; }
+
+        public string AssemblyPath { get; }
+
+        public bool DisabledByConfiguration { get; private set; }
+
+        public bool DisabledByUser { get; private set; }
+
+        public bool InitializationFailed { get; private set; }
+
+        public bool IsLoaded { get; private set; }
+
+        public bool IsEnabled
+        {
+            get => _isEnabled;
+            set
+            {
+                if (_isEnabled != value)
+                {
+                    _isEnabled = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string StatusMessage
+        {
+            get => _statusMessage;
+            private set
+            {
+                if (_statusMessage != value)
+                {
+                    _statusMessage = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public string LastUpdatedDisplay
+        {
+            get => _lastUpdatedDisplay;
+            private set
+            {
+                if (_lastUpdatedDisplay != value)
+                {
+                    _lastUpdatedDisplay = value;
+                    OnPropertyChanged();
+                }
+            }
+        }
+
+        public bool CanToggle => !DisabledByConfiguration;
+
+        public event PropertyChangedEventHandler? PropertyChanged;
+
+        public void Update(ExtensionSnapshot snapshot)
+        {
+            DisabledByConfiguration = snapshot.DisabledByConfiguration;
+            DisabledByUser = snapshot.DisabledByUser;
+            InitializationFailed = snapshot.InitializationFailed;
+            IsLoaded = snapshot.IsLoaded;
+            IsEnabled = snapshot.IsEnabled;
+            StatusMessage = snapshot.StatusMessage;
+            LastUpdatedDisplay = snapshot.LastUpdatedUtc.ToLocalTime().ToString("yyyy/MM/dd HH:mm");
+
+            OnPropertyChanged(nameof(DisabledByConfiguration));
+            OnPropertyChanged(nameof(DisabledByUser));
+            OnPropertyChanged(nameof(InitializationFailed));
+            OnPropertyChanged(nameof(IsLoaded));
+            OnPropertyChanged(nameof(CanToggle));
+        }
+
+        private void OnPropertyChanged([CallerMemberName] string? propertyName = null)
+        {
+            PropertyChanged?.Invoke(this, new PropertyChangedEventArgs(propertyName));
+        }
+    }
+}

--- a/WpfAppLauncher/Extensions/ExtensionManager.cs
+++ b/WpfAppLauncher/Extensions/ExtensionManager.cs
@@ -1,0 +1,579 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Reflection;
+using System.Runtime.Loader;
+using System.Threading;
+using Microsoft.Extensions.Configuration;
+using Serilog;
+using WpfAppLauncher.Configuration;
+
+namespace WpfAppLauncher.Extensions
+{
+    public sealed class ExtensionManager : IDisposable
+    {
+        private readonly AppSettings _settings;
+        private readonly ExtensionSettings _extensionSettings;
+        private readonly IConfiguration _configuration;
+        private readonly ILogger _logger;
+        private readonly IServiceProvider? _serviceProvider;
+        private readonly ExtensionStateStore _stateStore;
+        private readonly List<ManagedExtension> _extensions = new();
+        private readonly object _syncRoot = new();
+        private FileSystemWatcher? _watcher;
+        private Timer? _reloadTimer;
+        private bool _disposed;
+
+        private readonly string _extensionsDirectory;
+        private readonly string _extensionDataRootDirectory;
+
+        public ExtensionManager(AppSettings settings, IConfiguration configuration, ILogger logger, IServiceProvider? serviceProvider = null)
+        {
+            _settings = settings;
+            _extensionSettings = settings.Extensions;
+            _configuration = configuration;
+            _logger = logger;
+            _serviceProvider = serviceProvider;
+
+            _extensionsDirectory = Path.Combine(AppContext.BaseDirectory, _extensionSettings.DirectoryName);
+
+            var appDataDirectory = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                settings.AppData.ApplicationDirectoryName);
+
+            _extensionDataRootDirectory = Path.Combine(appDataDirectory, _extensionSettings.DataDirectoryName);
+
+            _stateStore = new ExtensionStateStore(settings.AppData, _extensionSettings, logger);
+        }
+
+        public event EventHandler<ExtensionsChangedEventArgs>? ExtensionsReloaded;
+
+        public void Initialize()
+        {
+            EnsureDirectories();
+            ReloadExtensions();
+            InitializeWatcher();
+        }
+
+        public IReadOnlyList<ExtensionSnapshot> GetExtensionsSnapshot()
+        {
+            lock (_syncRoot)
+            {
+                return CreateSnapshots();
+            }
+        }
+
+        public bool TryEnableExtension(string extensionId, out string? message)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(extensionId);
+
+            lock (_syncRoot)
+            {
+                var extension = FindExtension(extensionId);
+                if (extension is null)
+                {
+                    message = "指定された拡張機能が見つかりません。";
+                    return false;
+                }
+
+                if (extension.DisabledByConfiguration)
+                {
+                    message = "この拡張機能は構成ファイルによって無効化されています。";
+                    return false;
+                }
+
+                if (!extension.DisabledByUser)
+                {
+                    message = null;
+                    return true;
+                }
+            }
+
+            _stateStore.SetExtensionEnabled(extensionId, enabled: true);
+            ReloadExtensions();
+            message = null;
+            return true;
+        }
+
+        public bool TryDisableExtension(string extensionId, out string? message)
+        {
+            ArgumentException.ThrowIfNullOrWhiteSpace(extensionId);
+
+            lock (_syncRoot)
+            {
+                var extension = FindExtension(extensionId);
+                if (extension is null)
+                {
+                    message = "指定された拡張機能が見つかりません。";
+                    return false;
+                }
+
+                if (extension.DisabledByConfiguration)
+                {
+                    message = "構成で無効化されているため変更できません。";
+                    return false;
+                }
+            }
+
+            _stateStore.SetExtensionEnabled(extensionId, enabled: false);
+            ReloadExtensions();
+            message = null;
+            return true;
+        }
+
+        public void ReloadExtensions()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            IReadOnlyList<ExtensionSnapshot> snapshots;
+
+            lock (_syncRoot)
+            {
+                EnsureDirectories();
+                DisposeExtensions();
+
+                var disabledByConfiguration = new HashSet<string>(_extensionSettings.Disabled ?? Enumerable.Empty<string>(), StringComparer.OrdinalIgnoreCase);
+                var disabledByUser = new HashSet<string>(_stateStore.GetDisabledExtensionIds(), StringComparer.OrdinalIgnoreCase);
+
+                foreach (var assemblyPath in DiscoverAssemblies())
+                {
+                    LoadExtensionFromAssembly(assemblyPath, disabledByConfiguration, disabledByUser);
+                }
+
+                snapshots = CreateSnapshots();
+            }
+
+            ExtensionsReloaded?.Invoke(this, new ExtensionsChangedEventArgs(snapshots));
+        }
+
+        public void Dispose()
+        {
+            if (_disposed)
+            {
+                return;
+            }
+
+            _disposed = true;
+
+            lock (_syncRoot)
+            {
+                DisposeWatcher();
+                DisposeTimer();
+                DisposeExtensions();
+            }
+        }
+
+        private void EnsureDirectories()
+        {
+            Directory.CreateDirectory(_extensionsDirectory);
+            Directory.CreateDirectory(_extensionDataRootDirectory);
+        }
+
+        private IEnumerable<string> DiscoverAssemblies()
+        {
+            try
+            {
+                return Directory.EnumerateFiles(_extensionsDirectory, _extensionSettings.SearchPattern, SearchOption.TopDirectoryOnly).ToArray();
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "拡張機能フォルダーの列挙に失敗しました: {Directory}", _extensionsDirectory);
+                return Array.Empty<string>();
+            }
+        }
+
+        private void LoadExtensionFromAssembly(string assemblyPath, HashSet<string> disabledByConfiguration, HashSet<string> disabledByUser)
+        {
+            ExtensionLoadContext? loadContext = null;
+
+            try
+            {
+                loadContext = new ExtensionLoadContext(assemblyPath);
+
+                using var assemblyStream = new FileStream(assemblyPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                Stream? symbolStream = null;
+
+                var pdbPath = Path.ChangeExtension(assemblyPath, ".pdb");
+                if (!string.IsNullOrEmpty(pdbPath) && File.Exists(pdbPath))
+                {
+                    symbolStream = new FileStream(pdbPath, FileMode.Open, FileAccess.Read, FileShare.ReadWrite | FileShare.Delete);
+                }
+
+                using (symbolStream)
+                {
+                    var assembly = symbolStream is null
+                        ? loadContext.LoadFromStream(assemblyStream)
+                        : loadContext.LoadFromStream(assemblyStream, symbolStream);
+
+                    var extensionType = ResolveExtensionType(assembly);
+
+                    if (extensionType is null)
+                    {
+                        _logger.Warning("拡張機能のエントリーポイントが見つかりませんでした: {Assembly}", assemblyPath);
+                        loadContext.Unload();
+                        return;
+                    }
+
+                    var metadata = extensionType.GetCustomAttribute<ExtensionMetadataAttribute>();
+                    if (metadata is null)
+                    {
+                        _logger.Warning("ExtensionMetadataAttribute が見つかりません: {Type}", extensionType.FullName);
+                        loadContext.Unload();
+                        return;
+                    }
+
+                    var manifest = new ExtensionManifest(
+                        metadata.Id,
+                        string.IsNullOrWhiteSpace(metadata.DisplayName) ? extensionType.Name : metadata.DisplayName,
+                        metadata.Version,
+                        metadata.Description,
+                        assemblyPath,
+                        File.GetLastWriteTimeUtc(assemblyPath));
+
+                    var disabledByConfig = disabledByConfiguration.Contains(manifest.Id);
+                    var disabledByState = disabledByUser.Contains(manifest.Id);
+
+                    var managed = new ManagedExtension(manifest, disabledByConfig, disabledByState);
+
+                    if (_extensions.Any(existing => string.Equals(existing.Manifest.Id, manifest.Id, StringComparison.OrdinalIgnoreCase)))
+                    {
+                        _logger.Warning("拡張機能 ID {ExtensionId} は既に読み込まれているためスキップします。", manifest.Id);
+                        loadContext.Unload();
+                        return;
+                    }
+
+                    if (managed.CanActivate)
+                    {
+                        try
+                        {
+                            var logger = _logger
+                                .ForContext("ExtensionId", manifest.Id)
+                                .ForContext("ExtensionAssembly", Path.GetFileName(manifest.AssemblyPath));
+
+                            var extensionDataDirectory = Path.Combine(_extensionDataRootDirectory, manifest.Id);
+                            Directory.CreateDirectory(extensionDataDirectory);
+
+                            var context = new ExtensionInitializationContext(
+                                _serviceProvider,
+                                _configuration,
+                                logger,
+                                _extensionsDirectory,
+                                extensionDataDirectory);
+
+                            managed.Activate(extensionType, loadContext, context, logger);
+                            loadContext = null;
+                            _logger.Information("拡張機能 {ExtensionId} ({DisplayName}) を読み込みました。", manifest.Id, manifest.DisplayName);
+                        }
+                        catch (Exception ex)
+                        {
+                            managed.MarkFailed(ex);
+                            _logger.Error(ex, "拡張機能 {ExtensionId} の初期化に失敗しました。", manifest.Id);
+                            loadContext.Unload();
+                            loadContext = null;
+                        }
+                    }
+                    else
+                    {
+                        loadContext.Unload();
+                        loadContext = null;
+                        if (disabledByConfig)
+                        {
+                            _logger.Information("拡張機能 {ExtensionId} は構成により無効化されています。", manifest.Id);
+                        }
+                        else if (disabledByState)
+                        {
+                            _logger.Information("拡張機能 {ExtensionId} はユーザー設定により無効化されています。", manifest.Id);
+                        }
+                    }
+
+                    _extensions.Add(managed);
+                }
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                foreach (var loaderException in ex.LoaderExceptions)
+                {
+                    _logger.Error(loaderException, "拡張機能の読み込み中に依存関係エラーが発生しました: {Assembly}", assemblyPath);
+                }
+
+                loadContext?.Unload();
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "拡張機能アセンブリの読み込みに失敗しました: {Assembly}", assemblyPath);
+                loadContext?.Unload();
+            }
+        }
+
+        private static Type? ResolveExtensionType(Assembly assembly)
+        {
+            try
+            {
+                return assembly.GetTypes()
+                    .FirstOrDefault(type =>
+                        typeof(IAppExtension).IsAssignableFrom(type) &&
+                        !type.IsAbstract &&
+                        type.GetConstructor(Type.EmptyTypes) is not null);
+            }
+            catch (ReflectionTypeLoadException ex)
+            {
+                return ex.Types.FirstOrDefault(type =>
+                    type is not null &&
+                    typeof(IAppExtension).IsAssignableFrom(type) &&
+                    !type.IsAbstract &&
+                    type.GetConstructor(Type.EmptyTypes) is not null);
+            }
+        }
+
+        private ManagedExtension? FindExtension(string extensionId)
+        {
+            return _extensions.FirstOrDefault(extension =>
+                string.Equals(extension.Manifest.Id, extensionId, StringComparison.OrdinalIgnoreCase));
+        }
+
+        private IReadOnlyList<ExtensionSnapshot> CreateSnapshots()
+        {
+            return _extensions
+                .Select(extension => extension.ToSnapshot())
+                .ToArray();
+        }
+
+        private void InitializeWatcher()
+        {
+            if (!_extensionSettings.WatchForChanges)
+            {
+                return;
+            }
+
+            try
+            {
+                _watcher = new FileSystemWatcher(_extensionsDirectory)
+                {
+                    Filter = _extensionSettings.SearchPattern,
+                    IncludeSubdirectories = false,
+                    EnableRaisingEvents = true,
+                };
+
+                _watcher.Created += OnExtensionsDirectoryChanged;
+                _watcher.Changed += OnExtensionsDirectoryChanged;
+                _watcher.Deleted += OnExtensionsDirectoryChanged;
+                _watcher.Renamed += OnExtensionsDirectoryChanged;
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning(ex, "拡張機能フォルダーの監視を開始できませんでした: {Directory}", _extensionsDirectory);
+                DisposeWatcher();
+            }
+        }
+
+        private void OnExtensionsDirectoryChanged(object sender, FileSystemEventArgs e)
+        {
+            _logger.Information("拡張機能フォルダーで変更を検出しました: {ChangeType} {Path}", e.ChangeType, e.FullPath);
+            ScheduleReload();
+        }
+
+        private void ScheduleReload()
+        {
+            lock (_syncRoot)
+            {
+                _reloadTimer ??= new Timer(_ => SafeReload(), null, Timeout.Infinite, Timeout.Infinite);
+                _reloadTimer.Change(TimeSpan.FromMilliseconds(750), Timeout.InfiniteTimeSpan);
+            }
+        }
+
+        private void SafeReload()
+        {
+            try
+            {
+                ReloadExtensions();
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "拡張機能の自動再読み込みに失敗しました。");
+            }
+        }
+
+        private void DisposeExtensions()
+        {
+            foreach (var extension in _extensions)
+            {
+                extension.Dispose(_logger);
+            }
+
+            _extensions.Clear();
+        }
+
+        private void DisposeWatcher()
+        {
+            if (_watcher is null)
+            {
+                return;
+            }
+
+            _watcher.EnableRaisingEvents = false;
+            _watcher.Created -= OnExtensionsDirectoryChanged;
+            _watcher.Changed -= OnExtensionsDirectoryChanged;
+            _watcher.Deleted -= OnExtensionsDirectoryChanged;
+            _watcher.Renamed -= OnExtensionsDirectoryChanged;
+            _watcher.Dispose();
+            _watcher = null;
+        }
+
+        private void DisposeTimer()
+        {
+            _reloadTimer?.Dispose();
+            _reloadTimer = null;
+        }
+
+        private sealed class ManagedExtension
+        {
+            public ManagedExtension(ExtensionManifest manifest, bool disabledByConfiguration, bool disabledByUser)
+            {
+                Manifest = manifest;
+                DisabledByConfiguration = disabledByConfiguration;
+                DisabledByUser = disabledByUser;
+            }
+
+            public ExtensionManifest Manifest { get; }
+
+            public bool DisabledByConfiguration { get; }
+
+            public bool DisabledByUser { get; }
+
+            public bool CanActivate => !DisabledByConfiguration && !DisabledByUser;
+
+            public IAppExtension? Instance { get; private set; }
+
+            public ExtensionLoadContext? LoadContext { get; private set; }
+
+            public Exception? LastError { get; private set; }
+
+            public bool IsRuntimeLoaded => Instance is not null;
+
+            public void Activate(Type implementationType, ExtensionLoadContext loadContext, ExtensionInitializationContext context, ILogger logger)
+            {
+                var instance = (IAppExtension?)Activator.CreateInstance(implementationType)
+                    ?? throw new InvalidOperationException($"{implementationType.FullName} のインスタンスを作成できません。");
+
+                Instance = instance;
+                LoadContext = loadContext;
+
+                try
+                {
+                    instance.Initialize(context);
+                }
+                catch
+                {
+                    Dispose(logger);
+                    throw;
+                }
+            }
+
+            public void MarkFailed(Exception exception)
+            {
+                LastError = exception;
+            }
+
+            public ExtensionSnapshot ToSnapshot()
+            {
+                var status = BuildStatusMessage();
+
+                return new ExtensionSnapshot
+                {
+                    Id = Manifest.Id,
+                    DisplayName = Manifest.DisplayName,
+                    Version = Manifest.Version,
+                    Description = Manifest.Description,
+                    AssemblyPath = Manifest.AssemblyPath,
+                    LastUpdatedUtc = Manifest.LastUpdatedUtc,
+                    IsEnabled = !DisabledByUser && !DisabledByConfiguration,
+                    IsLoaded = IsRuntimeLoaded,
+                    DisabledByConfiguration = DisabledByConfiguration,
+                    DisabledByUser = DisabledByUser,
+                    InitializationFailed = LastError is not null,
+                    StatusMessage = status,
+                };
+            }
+
+            public void Dispose(ILogger logger)
+            {
+                if (Instance is IDisposable disposable)
+                {
+                    try
+                    {
+                        disposable.Dispose();
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Warning(ex, "拡張機能 {ExtensionId} の破棄処理でエラーが発生しました。", Manifest.Id);
+                    }
+                }
+
+                Instance = null;
+
+                if (LoadContext is not null)
+                {
+                    LoadContext.Unload();
+                    LoadContext = null;
+                }
+            }
+
+            private string BuildStatusMessage()
+            {
+                if (DisabledByConfiguration)
+                {
+                    return "構成で無効化";
+                }
+
+                if (DisabledByUser)
+                {
+                    return "ユーザーにより無効化";
+                }
+
+                if (LastError is not null)
+                {
+                    return $"初期化失敗: {LastError.Message}";
+                }
+
+                return IsRuntimeLoaded ? "有効" : "未読み込み";
+            }
+        }
+
+        private sealed record ExtensionManifest(
+            string Id,
+            string DisplayName,
+            string Version,
+            string? Description,
+            string AssemblyPath,
+            DateTime LastUpdatedUtc);
+
+        private sealed class ExtensionLoadContext : AssemblyLoadContext
+        {
+            private readonly AssemblyDependencyResolver _resolver;
+
+            public ExtensionLoadContext(string assemblyPath)
+                : base(isCollectible: true)
+            {
+                _resolver = new AssemblyDependencyResolver(assemblyPath);
+            }
+
+            protected override Assembly? Load(AssemblyName assemblyName)
+            {
+                var assemblyPath = _resolver.ResolveAssemblyToPath(assemblyName);
+                return assemblyPath is null ? null : LoadFromAssemblyPath(assemblyPath);
+            }
+
+            protected override IntPtr LoadUnmanagedDll(string unmanagedDllName)
+            {
+                var libraryPath = _resolver.ResolveUnmanagedDllToPath(unmanagedDllName);
+                return libraryPath is null
+                    ? base.LoadUnmanagedDll(unmanagedDllName)
+                    : LoadUnmanagedDllFromPath(libraryPath);
+            }
+        }
+    }
+}

--- a/WpfAppLauncher/Extensions/ExtensionManagerWindow.xaml
+++ b/WpfAppLauncher/Extensions/ExtensionManagerWindow.xaml
@@ -1,0 +1,65 @@
+<Window x:Class="WpfAppLauncher.Extensions.ExtensionManagerWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="拡張機能の管理"
+        Height="420"
+        Width="720"
+        WindowStartupLocation="CenterOwner"
+        Background="{DynamicResource BackgroundBrush}"
+        Foreground="{DynamicResource ForegroundBrush}">
+    <DockPanel Margin="10">
+        <StackPanel Orientation="Horizontal"
+                    DockPanel.Dock="Bottom"
+                    HorizontalAlignment="Right"
+                    Margin="0,10,0,0">
+            <Button Content="再読み込み"
+                    Margin="0,0,10,0"
+                    Padding="12,4"
+                    Click="ReloadButton_Click" />
+            <Button Content="閉じる"
+                    Padding="12,4"
+                    Click="CloseButton_Click" />
+        </StackPanel>
+
+        <ListView x:Name="ExtensionListView"
+                  Margin="0,0,0,10"
+                  HorizontalContentAlignment="Stretch">
+            <ListView.View>
+                <GridView>
+                    <GridViewColumn Header="有効" Width="60">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <CheckBox IsChecked="{Binding IsEnabled}"
+                                          IsEnabled="{Binding CanToggle}"
+                                          Tag="{Binding}"
+                                          Checked="ExtensionToggle_Checked"
+                                          Unchecked="ExtensionToggle_Unchecked" />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                    <GridViewColumn Header="名前" Width="180">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding DisplayName}"
+                                           ToolTip="{Binding Description}"
+                                           TextTrimming="CharacterEllipsis" />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                    <GridViewColumn Header="バージョン" Width="100"
+                                    DisplayMemberBinding="{Binding Version}" />
+                    <GridViewColumn Header="最終更新" Width="130"
+                                    DisplayMemberBinding="{Binding LastUpdatedDisplay}" />
+                    <GridViewColumn Header="状態" Width="200">
+                        <GridViewColumn.CellTemplate>
+                            <DataTemplate>
+                                <TextBlock Text="{Binding StatusMessage}"
+                                           TextWrapping="Wrap" />
+                            </DataTemplate>
+                        </GridViewColumn.CellTemplate>
+                    </GridViewColumn>
+                </GridView>
+            </ListView.View>
+        </ListView>
+    </DockPanel>
+</Window>

--- a/WpfAppLauncher/Extensions/ExtensionManagerWindow.xaml.cs
+++ b/WpfAppLauncher/Extensions/ExtensionManagerWindow.xaml.cs
@@ -1,0 +1,130 @@
+using System;
+using System.Collections.Generic;
+using System.Collections.ObjectModel;
+using System.Linq;
+using System.Windows;
+using System.Windows.Controls;
+
+namespace WpfAppLauncher.Extensions
+{
+    public partial class ExtensionManagerWindow : Window
+    {
+        private readonly ObservableCollection<ExtensionListItem> _extensions = new();
+        private bool _suppressToggleEvents;
+
+        public ExtensionManagerWindow()
+        {
+            InitializeComponent();
+            ExtensionListView.ItemsSource = _extensions;
+
+            if (ExtensionHost.IsInitialized)
+            {
+                LoadSnapshot(ExtensionHost.Manager.GetExtensionsSnapshot());
+                ExtensionHost.Manager.ExtensionsReloaded += OnExtensionsReloaded;
+            }
+        }
+
+        private void ReloadButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (ExtensionHost.IsInitialized)
+            {
+                ExtensionHost.Manager.ReloadExtensions();
+            }
+        }
+
+        private void CloseButton_Click(object sender, RoutedEventArgs e)
+        {
+            Close();
+        }
+
+        private void ExtensionToggle_Checked(object sender, RoutedEventArgs e)
+        {
+            HandleToggle(sender as CheckBox, enabled: true);
+        }
+
+        private void ExtensionToggle_Unchecked(object sender, RoutedEventArgs e)
+        {
+            HandleToggle(sender as CheckBox, enabled: false);
+        }
+
+        private void HandleToggle(CheckBox? checkBox, bool enabled)
+        {
+            if (_suppressToggleEvents || checkBox?.Tag is not ExtensionListItem item)
+            {
+                return;
+            }
+
+            if (!ExtensionHost.IsInitialized)
+            {
+                return;
+            }
+
+            bool result;
+            string? message;
+
+            if (enabled)
+            {
+                result = ExtensionHost.Manager.TryEnableExtension(item.Id, out message);
+            }
+            else
+            {
+                result = ExtensionHost.Manager.TryDisableExtension(item.Id, out message);
+            }
+
+            if (!result)
+            {
+                _suppressToggleEvents = true;
+                checkBox.IsChecked = !enabled;
+                _suppressToggleEvents = false;
+
+                if (!string.IsNullOrWhiteSpace(message))
+                {
+                    MessageBox.Show(this, message, "拡張機能", MessageBoxButton.OK, MessageBoxImage.Information);
+                }
+            }
+        }
+
+        private void LoadSnapshot(IReadOnlyList<ExtensionSnapshot> snapshots)
+        {
+            _suppressToggleEvents = true;
+
+            foreach (var snapshot in snapshots)
+            {
+                var item = _extensions.FirstOrDefault(x => string.Equals(x.Id, snapshot.Id, StringComparison.OrdinalIgnoreCase));
+                if (item is null)
+                {
+                    _extensions.Add(new ExtensionListItem(snapshot));
+                }
+                else
+                {
+                    item.Update(snapshot);
+                }
+            }
+
+            for (var index = _extensions.Count - 1; index >= 0; index--)
+            {
+                if (!snapshots.Any(snapshot => string.Equals(snapshot.Id, _extensions[index].Id, StringComparison.OrdinalIgnoreCase)))
+                {
+                    _extensions.RemoveAt(index);
+                }
+            }
+
+            _suppressToggleEvents = false;
+        }
+
+        private void OnExtensionsReloaded(object? sender, ExtensionsChangedEventArgs e)
+        {
+            Dispatcher.Invoke(() => LoadSnapshot(e.Extensions));
+        }
+
+        protected override void OnClosed(EventArgs e)
+        {
+            if (ExtensionHost.IsInitialized)
+            {
+                ExtensionHost.Manager.ExtensionsReloaded -= OnExtensionsReloaded;
+            }
+
+            base.OnClosed(e);
+        }
+    }
+}

--- a/WpfAppLauncher/Extensions/ExtensionMetadataAttribute.cs
+++ b/WpfAppLauncher/Extensions/ExtensionMetadataAttribute.cs
@@ -1,0 +1,53 @@
+using System;
+
+namespace WpfAppLauncher.Extensions
+{
+    /// <summary>
+    /// 拡張機能クラスに付与するメタデータ属性です。
+    /// </summary>
+    [AttributeUsage(AttributeTargets.Class, AllowMultiple = false, Inherited = false)]
+    public sealed class ExtensionMetadataAttribute : Attribute
+    {
+        public ExtensionMetadataAttribute(string id, string displayName, string version)
+        {
+            if (string.IsNullOrWhiteSpace(id))
+            {
+                throw new ArgumentException("拡張機能 ID を指定してください。", nameof(id));
+            }
+
+            if (string.IsNullOrWhiteSpace(displayName))
+            {
+                throw new ArgumentException("拡張機能名を指定してください。", nameof(displayName));
+            }
+
+            if (string.IsNullOrWhiteSpace(version))
+            {
+                throw new ArgumentException("バージョンを指定してください。", nameof(version));
+            }
+
+            Id = id;
+            DisplayName = displayName;
+            Version = version;
+        }
+
+        /// <summary>
+        /// 拡張機能を一意に識別する ID。
+        /// </summary>
+        public string Id { get; }
+
+        /// <summary>
+        /// UI に表示される拡張機能名。
+        /// </summary>
+        public string DisplayName { get; }
+
+        /// <summary>
+        /// 拡張機能のバージョン文字列。
+        /// </summary>
+        public string Version { get; }
+
+        /// <summary>
+        /// 拡張機能の簡単な説明。
+        /// </summary>
+        public string? Description { get; set; }
+    }
+}

--- a/WpfAppLauncher/Extensions/ExtensionSnapshot.cs
+++ b/WpfAppLauncher/Extensions/ExtensionSnapshot.cs
@@ -1,0 +1,34 @@
+using System;
+
+namespace WpfAppLauncher.Extensions
+{
+    /// <summary>
+    /// 拡張機能の状態スナップショットを表します。
+    /// </summary>
+    public sealed class ExtensionSnapshot
+    {
+        public string Id { get; init; } = string.Empty;
+
+        public string DisplayName { get; init; } = string.Empty;
+
+        public string Version { get; init; } = string.Empty;
+
+        public string? Description { get; init; }
+
+        public string AssemblyPath { get; init; } = string.Empty;
+
+        public DateTime LastUpdatedUtc { get; init; }
+
+        public bool IsEnabled { get; init; }
+
+        public bool IsLoaded { get; init; }
+
+        public bool DisabledByConfiguration { get; init; }
+
+        public bool DisabledByUser { get; init; }
+
+        public bool InitializationFailed { get; init; }
+
+        public string StatusMessage { get; init; } = string.Empty;
+    }
+}

--- a/WpfAppLauncher/Extensions/ExtensionStateStore.cs
+++ b/WpfAppLauncher/Extensions/ExtensionStateStore.cs
@@ -1,0 +1,106 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text.Json;
+using Serilog;
+using WpfAppLauncher.Configuration;
+
+namespace WpfAppLauncher.Extensions
+{
+    internal sealed class ExtensionStateStore
+    {
+        private readonly ILogger _logger;
+        private readonly string _stateFilePath;
+        private readonly object _syncRoot = new();
+        private StateModel _state;
+
+        public ExtensionStateStore(AppDataSettings appData, ExtensionSettings extensionSettings, ILogger logger)
+        {
+            _logger = logger;
+
+            var appDataDirectory = Path.Combine(
+                Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+                appData.ApplicationDirectoryName);
+
+            Directory.CreateDirectory(appDataDirectory);
+
+            _stateFilePath = Path.Combine(appDataDirectory, extensionSettings.StateFileName);
+            _state = LoadState();
+        }
+
+        public IReadOnlyCollection<string> GetDisabledExtensionIds()
+        {
+            lock (_syncRoot)
+            {
+                return _state.Disabled.Select(id => id).ToArray();
+            }
+        }
+
+        public void SetExtensionEnabled(string extensionId, bool enabled)
+        {
+            if (string.IsNullOrWhiteSpace(extensionId))
+            {
+                return;
+            }
+
+            lock (_syncRoot)
+            {
+                var comparer = StringComparer.OrdinalIgnoreCase;
+
+                if (enabled)
+                {
+                    _state.Disabled.RemoveAll(id => comparer.Equals(id, extensionId));
+                }
+                else if (_state.Disabled.All(id => !comparer.Equals(id, extensionId)))
+                {
+                    _state.Disabled.Add(extensionId);
+                }
+
+                SaveState();
+            }
+        }
+
+        private StateModel LoadState()
+        {
+            try
+            {
+                if (!File.Exists(_stateFilePath))
+                {
+                    return new StateModel();
+                }
+
+                var json = File.ReadAllText(_stateFilePath);
+                var state = JsonSerializer.Deserialize<StateModel>(json);
+                return state ?? new StateModel();
+            }
+            catch (Exception ex)
+            {
+                _logger.Warning(ex, "拡張機能の状態ファイルを読み込めませんでした。既定値を使用します: {StateFile}", _stateFilePath);
+                return new StateModel();
+            }
+        }
+
+        private void SaveState()
+        {
+            try
+            {
+                var json = JsonSerializer.Serialize(_state, new JsonSerializerOptions
+                {
+                    WriteIndented = true,
+                });
+
+                File.WriteAllText(_stateFilePath, json);
+            }
+            catch (Exception ex)
+            {
+                _logger.Error(ex, "拡張機能の状態ファイルを保存できませんでした: {StateFile}", _stateFilePath);
+            }
+        }
+
+        private sealed class StateModel
+        {
+            public List<string> Disabled { get; set; } = new();
+        }
+    }
+}

--- a/WpfAppLauncher/Extensions/ExtensionsChangedEventArgs.cs
+++ b/WpfAppLauncher/Extensions/ExtensionsChangedEventArgs.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Collections.Generic;
+
+namespace WpfAppLauncher.Extensions
+{
+    public sealed class ExtensionsChangedEventArgs : EventArgs
+    {
+        public ExtensionsChangedEventArgs(IReadOnlyList<ExtensionSnapshot> extensions)
+        {
+            Extensions = extensions ?? throw new ArgumentNullException(nameof(extensions));
+        }
+
+        public IReadOnlyList<ExtensionSnapshot> Extensions { get; }
+    }
+}

--- a/WpfAppLauncher/Extensions/IAppExtension.cs
+++ b/WpfAppLauncher/Extensions/IAppExtension.cs
@@ -1,0 +1,17 @@
+using System;
+
+namespace WpfAppLauncher.Extensions
+{
+    /// <summary>
+    /// 基本的な拡張機能のインターフェースです。各プラグインはこのインターフェースを実装し、
+    /// <see cref="ExtensionMetadataAttribute"/> を併せて指定する必要があります。
+    /// </summary>
+    public interface IAppExtension
+    {
+        /// <summary>
+        /// 拡張機能の初期化を行います。
+        /// </summary>
+        /// <param name="context">ホストから提供される初期化コンテキスト。</param>
+        void Initialize(ExtensionInitializationContext context);
+    }
+}

--- a/WpfAppLauncher/MainWindow.xaml
+++ b/WpfAppLauncher/MainWindow.xaml
@@ -12,12 +12,25 @@
 
     <DockPanel>
 
-        <!-- 固定テーマ切り替えパネル -->
-        <StackPanel x:Name="ThemePanel"
-                    Orientation="Horizontal"
-                    HorizontalAlignment="Right"
-                    DockPanel.Dock="Top"
-                    Margin="10" />
+        <!-- 上部コマンドバー -->
+        <Grid DockPanel.Dock="Top" Margin="10">
+            <Grid.ColumnDefinitions>
+                <ColumnDefinition Width="Auto" />
+                <ColumnDefinition Width="*" />
+            </Grid.ColumnDefinitions>
+
+            <Button x:Name="ExtensionManagerButton"
+                    Content="拡張機能..."
+                    Padding="12,4"
+                    Margin="0,0,10,0"
+                    HorizontalAlignment="Left"
+                    Click="ExtensionManagerButton_Click" />
+
+            <StackPanel x:Name="ThemePanel"
+                        Orientation="Horizontal"
+                        Grid.Column="1"
+                        HorizontalAlignment="Right" />
+        </Grid>
 
         <!-- グループ表示スクロール領域 -->
         <ScrollViewer VerticalScrollBarVisibility="Auto">

--- a/WpfAppLauncher/MainWindow.xaml.cs
+++ b/WpfAppLauncher/MainWindow.xaml.cs
@@ -7,6 +7,7 @@ using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Input;
 using WpfAppLauncher.Configuration;
+using WpfAppLauncher.Extensions;
 using WpfAppLauncher.Services;
 
 namespace WpfAppLauncher
@@ -59,6 +60,12 @@ namespace WpfAppLauncher
             {
                 ThemeSwitcher.SwitchTheme(settings.Themes.Default);
             }
+
+            ExtensionManagerButton.IsEnabled = ExtensionHost.IsInitialized;
+            if (!ExtensionHost.IsInitialized)
+            {
+                ExtensionManagerButton.ToolTip = "拡張機能の初期化に失敗しました。ログを確認してください。";
+            }
         }
 
         private void Window_DragEnter(object sender, DragEventArgs e)
@@ -90,6 +97,22 @@ namespace WpfAppLauncher
             {
                 File.WriteAllText(groupOrderPath, JsonSerializer.Serialize(groupOrder));
             }
+        }
+
+        private void ExtensionManagerButton_Click(object sender, RoutedEventArgs e)
+        {
+            if (!ExtensionHost.IsInitialized)
+            {
+                MessageBox.Show(this, "拡張機能システムが初期化されていないため、管理画面を開けません。", "拡張機能", MessageBoxButton.OK, MessageBoxImage.Information);
+                return;
+            }
+
+            var window = new ExtensionManagerWindow
+            {
+                Owner = this,
+            };
+
+            window.ShowDialog();
         }
     }
 }

--- a/WpfAppLauncher/appsettings.json
+++ b/WpfAppLauncher/appsettings.json
@@ -14,6 +14,14 @@
   "DragDrop": {
     "AllowedExtensions": [ ".exe", ".bat", ".lnk" ]
   },
+  "Extensions": {
+    "DirectoryName": "Extensions",
+    "DataDirectoryName": "Extensions",
+    "SearchPattern": "*.Extension.dll",
+    "StateFileName": "extensions.json",
+    "WatchForChanges": true,
+    "Disabled": []
+  },
   "Themes": {
     "Default": "LightTheme",
     "Options": [


### PR DESCRIPTION
## Summary
- introduce a configurable extension system that discovers plug-ins from the Extensions folder, loads them in isolated contexts, and watches for updates
- persist per-extension enablement in a dedicated state store while honoring configuration defaults and metadata requirements
- add an in-app extension manager window for enabling/disabling plug-ins and document the plug-in conventions

## Testing
- `dotnet build` *(fails: dotnet is not installed in the execution environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f744a0635c83288401f083e12f9609